### PR TITLE
While executing bundle install on the bootstrap node, it continuously…

### DIFF
--- a/cookbooks/bach_repository/recipes/gems.rb
+++ b/cookbooks/bach_repository/recipes/gems.rb
@@ -60,12 +60,9 @@ ruby_block 'determine-bundler-command' do
   block do
     gemfile_lock_path = File.join(node['bach']['repository']['repo_directory'],
                           'Gemfile.lock')
-    gemfile_lock_cmd = Mixlib::ShellOut.new('git', 'diff', '--name-status',
-                                            gemfile_lock_path)
-    gemfile_lock_cmd.run_command
-    if File.exists?(gemfile_lock_path) && !gemfile_lock_cmd.error?
+    if File.exists?(gemfile_lock_path) 
       node.run_state[:bcpc_bootstrap_bundler_command] =
-        "#{bundler_bin} install --deployment"
+        "rm -f #{gemfile_lock_path} && #{bundler_bin} --no-deployment && #{bundler_bin} --deployment"
     else
       node.run_state[:bcpc_bootstrap_bundler_command] =
         "#{bundler_bin} install"


### PR DESCRIPTION
… fails

as it expects an upgraded version but the Gemfile.lock is locked with a lower version.
Currently we are do not have Gemfile.lock in version control
Even when Gemfile.lock is updated with the upgraded version, still
it does not pick the same.
So the fix is to install the gems using '--deployment' switch to bundle command