### PR TITLE
tftpd-hpa to run on port 6900

### DIFF
--- a/cookbooks/bcpc/attributes/tftpd.rb
+++ b/cookbooks/bcpc/attributes/tftpd.rb
@@ -1,0 +1,2 @@
+# Port to run TFTPD 
+default['bcpc']['tftpd']['port'] = 6900

--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -68,6 +68,13 @@ node.force_default[:cobblerd][:web_password] = web_password
   end
 end
 
+#xinetd is already running on port 69
+#so let's start tftpd-hpa on port 6900
+template '/etc/default/tftpd-hpa' do
+	source 'cobbler/tftpd-hpa.erb'
+	mode 0644
+end
+
 #
 # Cobbler 2.6 expects to drop off a tftp configuration in
 # /etc/xinetd.d, so we stop the independent tftp service ASAP.

--- a/cookbooks/bcpc/templates/default/cobbler/tftpd-hpa.erb
+++ b/cookbooks/bcpc/templates/default/cobbler/tftpd-hpa.erb
@@ -1,0 +1,6 @@
+# /etc/default/tftpd-hpa
+
+TFTP_USERNAME="tftp"
+TFTP_DIRECTORY="/var/lib/tftpboot"
+TFTP_ADDRESS=":<%= node['bcpc']['tftpd']['port'] %>"
+TFTP_OPTIONS="--secure"


### PR DESCRIPTION
TFTP fails to start from the script
as it tries to run on the same port as xinetd which is 69
setting tftpd port to 6900